### PR TITLE
Item details view function

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,7 +24,6 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
     @user = @item.user
-    
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,6 +21,12 @@ class ItemsController < ApplicationController
       end
   end
 
+  def show
+    @item = Item.find(params[:id])
+    @user = @item.user
+    
+  end
+
   private
   def item_params
     params.require(:item).permit(:item_name, :description, :category_id, :condition_id, :deliveryfee_id, :prefecture_id, :shipdate_id, :price, :image).merge(user_id: current_user.id)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,6 +130,7 @@
     
      <% @items.each do |item| %>
       <li class='list'>
+         <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
@@ -152,8 +153,9 @@
             </div>
           </div>
         </div>
-     <% end %>
+       <% end %>
       </li>
+     <% end %>
    
      <% unless @items.exists?%>
       <li class='list'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,19 +23,21 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
+  <% if user_signed_in? && current_user.id == @item.user_id %> 
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
+  <% end %>
+    
+    <% if user_signed_in? && current_user.id != @item.user_id %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,7 @@
       </span>
     </div>
 
-
+    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
   <% if user_signed_in? && current_user.id == @item.user_id %> 
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
@@ -105,9 +105,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+   <a href="#" class="another-item"><%= @item.category[:name] %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.deliveryfee[:name] %>
       </span>
     </div>
 
@@ -38,33 +38,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.deliveryfee[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipdate[:name] %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 
 end


### PR DESCRIPTION
## What
出品された画像や文字をクリックすると商品詳細ページに遷移する。
また、ユーザーのログイン状況によって、行える挙動を変える。

## Why
出品者が自分の出品物を購入できたり、未ログインユーザーが購入できたり、出品者以外が出品物を編集や削除できては、サービスの設計上好ましくないため、ログイン状況によって挙動の分岐を行った。


## Notes
商品購入機能は未実装です。

## 挙動確認動画
動画は以下を前提条件とします。
- 出品者はayakoでCameraを出品している
- 購入者はtaro

- ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/079e820fc7e67e3c2a5b184afa5292f8

- ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/7ecc5e69b80ac56752b815f9f1d92b6f

- ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
商品購入機能は未実装です。

- ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/a4ac3d85f0e06377e02570df969de51d


